### PR TITLE
Upgrade to NullAway 0.12.11 and Error Prone 2.42.0

### DIFF
--- a/src/main/java/io/spring/gradle/nullability/NullabilityPluginExtension.java
+++ b/src/main/java/io/spring/gradle/nullability/NullabilityPluginExtension.java
@@ -25,9 +25,9 @@ import org.gradle.api.provider.Property;
  */
 public abstract class NullabilityPluginExtension {
 
-	static final String ERROR_PRONE_VERSION = "2.41.0";
+	static final String ERROR_PRONE_VERSION = "2.42.0";
 
-	static final String NULL_AWAY_VERSION = "0.12.10";
+	static final String NULL_AWAY_VERSION = "0.12.11";
 
 	/**
 	 * Internal use only.


### PR DESCRIPTION
See https://github.com/uber/NullAway/releases/tag/v0.12.11.

That's an important version that now check if a supported Java version is used, preventing a lot of invalid setup, see https://github.com/uber/NullAway/pull/1317 for more details.